### PR TITLE
Fix handlebars typing

### DIFF
--- a/lib/engines/handlebars.ts
+++ b/lib/engines/handlebars.ts
@@ -1,9 +1,11 @@
 import handlebars from "https://dev.jspm.io/handlebars@4.7.6";
 import { Engine } from "../types/index.ts";
 
+const hb = <any> handlebars;
+
 export const renderHandlebars: Engine = (
   template: string,
   data: object = {},
 ): string => {
-  return handlebars.compile(template)(data);
+  return hb.compile(template)(data);
 };


### PR DESCRIPTION
I just casted the untyped handlebars lib to `any` to avoid issues during deno bundle.

Fixes the following error:
```
➜  view-engine (5025391) ✔ deno bundle mod.ts
Bundling file:///home/alicegg/Personal/contrib/view-engine/mod.ts
error: TS2339 [ERROR]: Property 'compile' does not exist on type '{}'.
  return handlebars.compile(template)(data);
                    ~~~~~~~
    at file:///home/alicegg/Personal/contrib/view-engine/lib/engines/handlebars.ts:8:21
```