### PR TITLE
Fix eta view path

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,7 +5,7 @@ export * as path from "https://deno.land/std@0.131.0/path/mod.ts";
 export { green, blue } from "https://deno.land/std@0.131.0/fmt/colors.ts";
 export { assertEquals, assert } from "https://deno.land/std@0.131.0/testing/asserts.ts";
 
-export { Application } from "https://deno.land/x/oak@v10.5.1/mod.ts";
+export { Application } from "https://deno.land/x/oak@v10.6.0/mod.ts";
 
 
 export * as eta from 'https://deno.land/x/eta@v1.12.3/mod.ts'

--- a/lib/adapters/oak/oak.adapter.ts
+++ b/lib/adapters/oak/oak.adapter.ts
@@ -2,12 +2,12 @@ import type {
   Context,
   RouteParams,
   State,
-} from "https://deno.land/x/oak@v10.5.1/mod.ts";
+} from "https://deno.land/x/oak@v10.6.0/mod.ts";
 
 import type { ViewConfig,Adapter,Engine } from "../../viewEngine.type.ts";
 import { getTemplate } from "./oak.utils.ts";
 
-declare module "https://deno.land/x/oak@v10.5.1/mod.ts" {
+declare module "https://deno.land/x/oak@v10.6.0/mod.ts" {
   // App level Context
   interface Context {
     render: (fileName: string, data?: object) => void;

--- a/lib/engines/eta/eta.engine.ts
+++ b/lib/engines/eta/eta.engine.ts
@@ -8,6 +8,10 @@ export const etaEngine: Engine = async (
   filename: string = ""
 ): Promise<string> => {
 
+  if (config.viewRoot) {
+    eta.configure({ views: config.viewRoot });
+  }
+
   return new Promise<string>(async (resolve, reject) => {
     try{
       const result = await eta.render( template, data) as string


### PR DESCRIPTION
This fixes eta not being able to find .eta files even when you set the view in viewEngine({viewRoot: })
Formated to stay in line with how denjuck.engine.ts has a similar property already