### PR TITLE
Added Oak v13.0.0 and Eta 3 support

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,15 +1,16 @@
-export { existsSync } from "https://deno.land/std@0.131.0/fs/exists.ts";
-export * as path from "https://deno.land/std@0.131.0/path/mod.ts";
+export { existsSync } from "https://deno.land/std@0.214.0/fs/exists.ts";
+export * as path from "https://deno.land/std@0.214.0/path/mod.ts";
 
 // test dependencies
-export { green, blue } from "https://deno.land/std@0.131.0/fmt/colors.ts";
+export { green, blue } from "https://deno.land/std@0.214.0/fmt/colors.ts";
 export {
   assertEquals,
   assert,
-} from "https://deno.land/std@0.131.0/testing/asserts.ts";
+} from "https://deno.land/std@0.214.0/testing/asserts.ts";
 
-export { Application } from "https://deno.land/x/oak@v10.6.0/mod.ts";
+export { Application } from "https://deno.land/x/oak@v13.0.0/mod.ts";
 
-export * as eta from "https://deno.land/x/eta@v1.12.3/mod.ts";
-export * as dejs from "https://deno.land/x/dejs@0.10.2/mod.ts";
-export * as pug from "https://deno.land/x/pug@v0.1.3/mod.ts";
+import { Eta } from "npm:eta";
+export const eta = new Eta();
+export * as dejs from "https://deno.land/x/dejs@0.10.3/mod.ts";
+export * as pug from "npm:pug";

--- a/deps.ts
+++ b/deps.ts
@@ -8,7 +8,7 @@ export {
   assert,
 } from "https://deno.land/std@0.214.0/testing/asserts.ts";
 
-export { Application } from "https://deno.land/x/oak@v13.0.0/mod.ts";
+export { Application, Context, type MiddlewareOrMiddlewareObject } from "https://deno.land/x/oak@v13.0.0/mod.ts";
 
 import { Eta } from "npm:eta";
 export const eta = new Eta();

--- a/lib/adapters/oak/oak.adapter.ts
+++ b/lib/adapters/oak/oak.adapter.ts
@@ -1,21 +1,20 @@
 import type {
   Context,
+  MiddlewareOrMiddlewareObject,
   RouteParams,
   State,
 } from "https://deno.land/x/oak@v13.0.0/mod.ts";
 
-import type { ViewConfig,Adapter,Engine } from "../../viewEngine.type.ts";
-import { getTemplate } from "./oak.utils.ts";
-import { path } from "../../../deps.ts";
+import type { ViewConfig,Engine } from "../../viewEngine.type.ts";
 
 declare module "https://deno.land/x/oak@v13.0.0/mod.ts" {
   // App level Context
-  export interface Context {
+  interface Context {
     render: (fileName: string, data?: object) => void;
   }
 
   // Router level Context
-  export interface RouterContext<
+  interface RouterContext<
     R extends string,
     P extends RouteParams<R> = RouteParams<R>,
     // deno-lint-ignore no-explicit-any
@@ -25,13 +24,12 @@ declare module "https://deno.land/x/oak@v13.0.0/mod.ts" {
   }
 
   // add viewConfig to Application interface
-  export interface Application {
+  interface Application {
     viewConfig: ViewConfig;
   }
 }
-export type { Context, ViewConfig, Adapter, Engine };
 //! Add `render` function to Context
-export const oakAdapter: Adapter = (
+export const oakAdapter = <T extends MiddlewareOrMiddlewareObject>(
   renderEngine: Engine,
   config: ViewConfig = <ViewConfig>{}
 ) => {
@@ -46,8 +44,6 @@ export const oakAdapter: Adapter = (
 
     ctx.render = (fileName: string, data?: object) =>{
       try {
-        const viewConfig = ctx.app.viewConfig;
-
         ctx.response.headers.set("Content-Type", "text/html; charset=utf-8");
         
         ctx.response.body = () => {
@@ -66,5 +62,5 @@ export const oakAdapter: Adapter = (
     };
 
     await next();
-  };
+  } as T;
 };

--- a/lib/adapters/oak/oak.adapter.ts
+++ b/lib/adapters/oak/oak.adapter.ts
@@ -2,19 +2,20 @@ import type {
   Context,
   RouteParams,
   State,
-} from "https://deno.land/x/oak@v10.6.0/mod.ts";
+} from "https://deno.land/x/oak@v13.0.0/mod.ts";
 
 import type { ViewConfig,Adapter,Engine } from "../../viewEngine.type.ts";
 import { getTemplate } from "./oak.utils.ts";
+import { path } from "../../../deps.ts";
 
-declare module "https://deno.land/x/oak@v10.6.0/mod.ts" {
+declare module "https://deno.land/x/oak@v13.0.0/mod.ts" {
   // App level Context
-  interface Context {
+  export interface Context {
     render: (fileName: string, data?: object) => void;
   }
 
   // Router level Context
-  interface RouterContext<
+  export interface RouterContext<
     R extends string,
     P extends RouteParams<R> = RouteParams<R>,
     // deno-lint-ignore no-explicit-any
@@ -24,17 +25,17 @@ declare module "https://deno.land/x/oak@v10.6.0/mod.ts" {
   }
 
   // add viewConfig to Application interface
-  interface Application {
+  export interface Application {
     viewConfig: ViewConfig;
   }
 }
-
+export type { Context, ViewConfig, Adapter, Engine };
 //! Add `render` function to Context
 export const oakAdapter: Adapter = (
   renderEngine: Engine,
   config: ViewConfig = <ViewConfig>{}
 ) => {
-  return async function (ctx: Context, next: Function) {
+  return async function (ctx: Context, next: () => Promise<unknown>) {
     // load default view setting
     if (!ctx.app.viewConfig) {
       ctx.app.viewConfig = {
@@ -43,15 +44,15 @@ export const oakAdapter: Adapter = (
       };
     }
 
-    ctx.render = async (fileName: string, data?: object) =>{
+    ctx.render = (fileName: string, data?: object) =>{
       try {
         const viewConfig = ctx.app.viewConfig;
 
         ctx.response.headers.set("Content-Type", "text/html; charset=utf-8");
         
-        ctx.response.body = async () => {
+        ctx.response.body = () => {
           return renderEngine(
-            await getTemplate(viewConfig.viewRoot ??"./", fileName),
+            fileName,
             data ?? {},
             ctx.app.viewConfig,
             fileName

--- a/lib/adapters/oak/oak.utils.ts
+++ b/lib/adapters/oak/oak.utils.ts
@@ -1,7 +1,7 @@
 import { path } from "../../../deps.ts";
 
-const urlRegex =
-/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
+// const urlRegex =
+// /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
 
 
 export async function getTemplate(viewRoot: string, fileName: string) {

--- a/lib/adapters/oak/oak_test.ts
+++ b/lib/adapters/oak/oak_test.ts
@@ -1,5 +1,5 @@
 // app.ts
-import { Application, green, assertEquals, assert } from "../../../deps.ts";
+import { Application, green, assert } from "../../../deps.ts";
 
 import {
   viewEngine,
@@ -7,7 +7,7 @@ import {
   dejsEngine
 } from "../../../mod.ts";
 //import declaration from the oak.adapter.ts file
-const removeRegex = /\r?\n|\r|\s/g;
+// const removeRegex = /\r?\n|\r|\s/g;
 
 Deno.test({
   name: green("Testing Oak - dejsEngine"),
@@ -17,7 +17,7 @@ Deno.test({
     const app = new Application();
     app.use(viewEngine(oakAdapter, dejsEngine, { viewRoot: "./views/ejs" }));
 
-    app.use(async (ctx, next) => {
+    app.use((ctx, _) => {
       ctx.render("index.ejs", { data: { name: "John" } });
     });
     setTimeout(async () => {

--- a/lib/adapters/oak/oak_test.ts
+++ b/lib/adapters/oak/oak_test.ts
@@ -1,11 +1,12 @@
 // app.ts
 import { Application, green, assertEquals, assert } from "../../../deps.ts";
+
 import {
   viewEngine,
   oakAdapter,
   dejsEngine
 } from "../../../mod.ts";
-
+//import declaration from the oak.adapter.ts file
 const removeRegex = /\r?\n|\r|\s/g;
 
 Deno.test({

--- a/lib/engines/dejs/dejs.engine.ts
+++ b/lib/engines/dejs/dejs.engine.ts
@@ -1,16 +1,16 @@
 import { dejs } from "../../../deps.ts";
 import type { Engine, ViewConfig } from "../../viewEngine.type.ts";
 
-export const dejsEngine: Engine = async (
+export const dejsEngine: Engine = (
   template: string,
   data: object = {},
-  config: ViewConfig = {},
-  filename: string = ""
+  _config: ViewConfig = {},
+  _filename = ""
 ): Promise<string> => {
 
-  return new Promise<string>(async (resolve, reject) => {
+  return new Promise<string>( (resolve, reject) => {
     try{
-      const result = await dejs.renderToString(template, data) 
+      const result = dejs.renderToString(template, data) 
       resolve(result)
     }catch(e){
       reject(e)

--- a/lib/engines/denjuck/denjuck.engine.ts
+++ b/lib/engines/denjuck/denjuck.engine.ts
@@ -1,4 +1,4 @@
-// @deno-types="https://deno.land/x/denjucks/mod.d.ts"
+// @deno-types="https://deno.land/x/denjucks@1.1.1/mod.d.ts"
 import denjucks from "https://raw.githubusercontent.com/lumeland/denjucks/v2.0.0/mod.js";
 import type { Engine,ViewConfig } from "../../viewEngine.type.ts";
 
@@ -6,7 +6,7 @@ export const denjuckEngine: Engine = (
   template: string,
   data: object = {},
   config: ViewConfig = {},
-  filename: string = "",
+  _filename = "",
 ) => {
 
   if (config.viewRoot) {

--- a/lib/engines/eta/eta.engine.ts
+++ b/lib/engines/eta/eta.engine.ts
@@ -1,7 +1,7 @@
 import { eta } from "../../../deps.ts";
 import type { Engine, ViewConfig } from "../../viewEngine.type.ts";
 
-export const etaEngine: Engine = async (
+export const etaEngine: Engine = (
   template: string,
   data: object = {},
   config: ViewConfig = {},
@@ -11,10 +11,9 @@ export const etaEngine: Engine = async (
   if (config.viewRoot) {
     eta.configure({ views: config.viewRoot });
   }
-
-  return new Promise<string>(async (resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     try{
-      const result = await eta.render( template, data) as string
+      const result = eta.render(template, data) as string
       resolve(result)
     }catch(e){
       reject(e)

--- a/lib/engines/eta/eta.engine.ts
+++ b/lib/engines/eta/eta.engine.ts
@@ -5,7 +5,7 @@ export const etaEngine: Engine = (
   template: string,
   data: object = {},
   config: ViewConfig = {},
-  filename: string = ""
+  _filename = ""
 ): Promise<string> => {
 
   if (config.viewRoot) {

--- a/lib/engines/handlebars/handlebars.engine.ts
+++ b/lib/engines/handlebars/handlebars.engine.ts
@@ -1,13 +1,13 @@
-import handlebars from "https://jspm.dev/handlebars@4.7.6";
+import handlebars from "npm:handlebars";
 import type { Engine,ViewConfig } from "../../viewEngine.type.ts";
 
-export const hbs = <any> handlebars;
+export const hbs = handlebars;
 
 export const handlebarsEngine: Engine = (
   template: string,
   data: object = {},
-  config: ViewConfig = {},
-  filename: string = "",
+  _config: ViewConfig = {},
+  _filename = "",
 
 ) => {
   return new Promise<string>((resolve, reject) => {

--- a/lib/engines/pug/pug.engine.ts
+++ b/lib/engines/pug/pug.engine.ts
@@ -1,7 +1,7 @@
 import { path, pug } from "../../../deps.ts";
 import { Engine, ViewConfig } from "../../viewEngine.type.ts";
 
-export const pugEngine: Engine = async (
+export const pugEngine: Engine = (
   template: string,
   data: object = {},
   config: ViewConfig = {},

--- a/lib/viewEngine.ts
+++ b/lib/viewEngine.ts
@@ -1,9 +1,9 @@
 import type { Adapter, Engine, ViewConfig } from "./viewEngine.type.ts";
 
-export function viewEngine(
-  adapter: Adapter,
+export function viewEngine<TAdapterMiddleware>(
+  adapter: Adapter<TAdapterMiddleware>,
   engine: Engine,
   config: ViewConfig = <ViewConfig>{}
-): any {
+): TAdapterMiddleware {
   return adapter(engine, config);
 }

--- a/lib/viewEngine.type.ts
+++ b/lib/viewEngine.type.ts
@@ -1,12 +1,19 @@
+import {  MiddlewareOrMiddlewareObject } from "../deps.ts";
+
 export interface ViewConfig {
   viewRoot?: string;
   viewEngine?: Engine | undefined;
 }
 
-export type Adapter = (
+export type AdapterMiddleware<T, TContext> = (
+  context: TContext,
+  next: () => Promise<unknown>,
+) => Promise<T>;
+
+export type Adapter<T = MiddlewareOrMiddlewareObject> = (
   renderEngine: Engine,
   config: ViewConfig,
-) => void;
+) => T;
 
 export type Engine = (
   template: string,

--- a/readme.md
+++ b/readme.md
@@ -82,8 +82,8 @@ Suppose you have a folder like this:
 ```
 ```ts
 // app.ts
-import { Application } from "https://deno.land/x/oak@v10.5.1/mod.ts";
-import { viewEngine, ejsEngine, oakAdapter } from "https://deno.land/x/view_engine@v10.5.1c/mod.ts"
+import { Application } from "https://deno.land/x/oak@v13.0.0/mod.ts";
+import { viewEngine, etaEngine, oakAdapter } from "https://deno.land/x/view_engine@v11.0.0/mod.ts"
 
 const app = new Application();
 


### PR DESCRIPTION
If this project is still alive, this PR fixes incompatibility between latest version of Oak and ETA template engine...

Please know that i haven't yet done much testing, i just updated the code until it worked on my new project using these versions.

Checking if the other template engine is required before you merge/use this PR, if this never gets merged i will make sure to update my fork accordingly. 