### PR TITLE
Fix typos in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,6 @@ viewEngine(
 
 #### 🎛Adapter
 
-
 ```ts
 import { oakAdapter } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
 
@@ -50,8 +49,10 @@ import { oakAdapter } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
 
 #### 🚀Engine
 
+The packaged engines include: `denjuckEngine`, `handlebarsEngine`, `dejsEngine`, and `etaEngine`. 
+
 ```ts
-import { etaEngine, ejsEngine, denjuckEngine, handlebarsEngine } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
+import { etaEngine } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
 ```
 
 #### ⚙ViewConfig
@@ -68,10 +69,11 @@ const viewConfig: ViewConfig = {
 
 #### Use [Oak](https://github.com/oakserver/oak) to render `eta` template at `./views/eta/index.eta`
 
-Suppose you have a folder like this: 
+Create the directory `src/views/eta/` and add an `index.eta file`. Your project directory should look something like this:
+
 ```
-/src/views/eta/index.eta
-/src/app.ts
+src/views/eta/index.eta
+src/app.ts
 ```
 
 ```html

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ import { oakAdapter } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
 #### 🚀Engine
 
 ```ts
-import { ejsEngine, denjuckEngine, handlebarsEngine } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
+import { etaEngine, ejsEngine, denjuckEngine, handlebarsEngine } from "https://deno.land/x/view_engine@v10.6.0/mod.ts"
 ```
 
 #### ⚙ViewConfig
@@ -70,12 +70,12 @@ const viewConfig: ViewConfig = {
 
 Suppose you have a folder like this: 
 ```
-/views/index.ejs
-/app.ts
+/src/views/eta/index.eta
+/src/app.ts
 ```
 
 ```html
-<!--index.html-->
+<!--index.eta-->
 <body>
   Hobbies of <%=it.name%> 
 </body>
@@ -83,7 +83,7 @@ Suppose you have a folder like this:
 ```ts
 // app.ts
 import { Application } from "https://deno.land/x/oak@v10.5.1/mod.ts";
-import { viewEngine, ejsEngine, oakAdapter } from "https://deno.land/x/view_engine@v10.5.1c/mod.ts"
+import { viewEngine, etaEngine, oakAdapter } from "https://deno.land/x/view_engine@v10.5.1c/mod.ts"
 
 const app = new Application();
 


### PR DESCRIPTION
Two fixes:

**Consistently refer to ETA in the README example**

The README example intermixes HTML, EJS, and ETA which is confusing for a noob. This commit updates the examples to refer to eta alone. This should make it easier for new users to jump in without confusion.

**Update list of engines**

The list of engines is out of date. This updates the list of engines to match the ones currently packaged with view-engine. Makes some instructions more explicit.